### PR TITLE
CJ: updating Java to 8u66

### DIFF
--- a/docker/joynr-base/Dockerfile
+++ b/docker/joynr-base/Dockerfile
@@ -54,14 +54,14 @@ RUN yum update -y \
 ###################################################
 RUN cd /opt \
 	&& wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" \
-		"http://download.oracle.com/otn-pub/java/jdk/8u40-b26/jdk-8u40-linux-x64.tar.gz"
+		"http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-x64.tar.gz"
 
 RUN cd /opt \
-	&& tar xvf jdk-8u40-linux-x64.tar.gz \
-	&& alternatives --install /usr/bin/java java /opt/jdk1.8.0_40/bin/java 18000400 \
-	&& alternatives --install /usr/bin/javac javac /opt/jdk1.8.0_40/bin/javac 18000400 \
-	&& alternatives --install /usr/bin/jar jar /opt/jdk1.8.0_40/bin/jar 18000400 \
-	&& rm /opt/jdk-8u40-linux-x64.tar.gz
+	&& tar xvf jdk-8u66-linux-x64.tar.gz \
+	&& alternatives --install /usr/bin/java java /opt/jdk1.8.0_66/bin/java 18000400 \
+	&& alternatives --install /usr/bin/javac javac /opt/jdk1.8.0_66/bin/javac 18000400 \
+	&& alternatives --install /usr/bin/jar jar /opt/jdk1.8.0_66/bin/jar 18000400 \
+	&& rm /opt/jdk-8u66-linux-x64.tar.gz
 
 ###################################################
 # install Maven


### PR DESCRIPTION
Updating the java installed in the joynr-base Docker image to the currently current 8u66 release.