### PR TITLE
[Java] move creation of required unit test resources into separate shell script

### DIFF
--- a/docker/joynr-android/scripts/build/java-android-clean-build
+++ b/docker/joynr-android/scripts/build/java-android-clean-build
@@ -24,36 +24,6 @@ while [ "$1" != "" ]; do
 done
 
 echo '####################################################'
-echo '# create keystore and truststore'
-echo '####################################################'
-
-CERT_PATH='/data/ssl-data/certs'
-PRIVATE_KEY_PATH='/data/ssl-data/private'
-KEYSTORE_PASSWORD='password'
-
-mkdir -p /data/src/java/messaging/mqtt/joynr-mqtt-client/src/test/resources
-
-cd /data/src/java/messaging/mqtt/joynr-mqtt-client/src/test/resources/
-
-# create JKS truststore
-keytool -keystore catruststore.jks -importcert -file $CERT_PATH/ca.cert.pem -storepass $KEYSTORE_PASSWORD -trustcacerts -noprompt
-
-# list the truststore contents
-keytool -list -keystore catruststore.jks -storepass $KEYSTORE_PASSWORD
-
-# create PKCS12 truststore
-keytool -importkeystore -srckeystore catruststore.jks -srcstorepass $KEYSTORE_PASSWORD -destkeystore catruststore.p12 -deststorepass $KEYSTORE_PASSWORD -srcstoretype JKS -deststoretype PKCS12
-
-# merge and import client certificate and private key into pkcs12 keystore
-openssl pkcs12 -export -in $CERT_PATH/client.cert.pem -inkey $PRIVATE_KEY_PATH/client.key.pem -out clientkeystore.p12 -password pass:$KEYSTORE_PASSWORD
-
-# convert pkcs12 keystore into java keystore
-keytool -importkeystore -deststorepass $KEYSTORE_PASSWORD -destkeypass $KEYSTORE_PASSWORD -destkeystore clientkeystore.jks -srckeystore clientkeystore.p12 -srcstoretype PKCS12 -srcstorepass $KEYSTORE_PASSWORD -alias 1 -storepass $KEYSTORE_PASSWORD
-
-# list the keystore contents
-keytool -list -keystore clientkeystore.jks -storepass $KEYSTORE_PASSWORD
-
-echo '####################################################'
 echo '# start tests'
 echo '####################################################'
 

--- a/docker/joynr-base/Dockerfile
+++ b/docker/joynr-base/Dockerfile
@@ -70,6 +70,11 @@ ENV SRC_DIR /data/src
 ENV INSTALL_DIR /data/install
 
 ###################################################
+# set joynr-docker-environment
+###################################################
+ENV JOYNR_DOCKER_ENVIRONMENT true
+
+###################################################
 # copy scripts and set start command
 ###################################################
 COPY scripts /data/scripts

--- a/java/messaging/mqtt/joynr-mqtt-client/pom.xml
+++ b/java/messaging/mqtt/joynr-mqtt-client/pom.xml
@@ -60,10 +60,9 @@
 			<plugin>
 				<artifactId>exec-maven-plugin</artifactId>
 				<groupId>org.codehaus.mojo</groupId>
-				<version>1.6.0</version>
 				<executions>
 					<execution>
-						<id>generate required sources</id>
+						<id>generate-java-keystore-truststore</id>
 						<phase>generate-test-resources</phase>
 						<goals>
 							<goal>exec</goal>

--- a/java/messaging/mqtt/joynr-mqtt-client/pom.xml
+++ b/java/messaging/mqtt/joynr-mqtt-client/pom.xml
@@ -55,4 +55,30 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>exec-maven-plugin</artifactId>
+				<groupId>org.codehaus.mojo</groupId>
+				<version>1.6.0</version>
+				<executions>
+					<execution>
+						<id>generate required sources</id>
+						<phase>generate-test-resources</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>${basedir}/scripts/gen-java-keystore-truststore.sh</executable>
+							<arguments>
+								<argument>--destdir</argument>
+								<argument>${basedir}/src/test/resources</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/java/messaging/mqtt/joynr-mqtt-client/pom.xml
+++ b/java/messaging/mqtt/joynr-mqtt-client/pom.xml
@@ -55,29 +55,39 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>exec-maven-plugin</artifactId>
-				<groupId>org.codehaus.mojo</groupId>
-				<executions>
-					<execution>
-						<id>generate-java-keystore-truststore</id>
-						<phase>generate-test-resources</phase>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-						<configuration>
-							<executable>${basedir}/scripts/gen-java-keystore-truststore.sh</executable>
-							<arguments>
-								<argument>--destdir</argument>
-								<argument>${basedir}/src/test/resources</argument>
-							</arguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+		<profiles>
+		<profile>
+			<id>joynr-docker-environment</id>
+			<activation>
+				<property>
+					<name>env.JOYNR_DOCKER_ENVIRONMENT</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>exec-maven-plugin</artifactId>
+						<groupId>org.codehaus.mojo</groupId>
+						<executions>
+							<execution>
+								<id>generate required sources</id>
+								<phase>generate-test-resources</phase>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+								<configuration>
+									<executable>${basedir}/scripts/gen-java-keystore-truststore.sh</executable>
+									<arguments>
+										<argument>--destdir</argument>
+										<argument>${basedir}/src/test/resources</argument>
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/java/messaging/mqtt/joynr-mqtt-client/scripts/gen-java-keystore-truststore.sh
+++ b/java/messaging/mqtt/joynr-mqtt-client/scripts/gen-java-keystore-truststore.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+DEST_DIR='.'
+KEYSTORE_PASSWORD='password'
+
+# these files are located inside the docker image 
+CERT_PATH='/data/ssl-data/certs'
+PRIVATE_KEY_PATH='/data/ssl-data/private'
+
+function usage
+{
+    echo "usage: gen-java-keystore-truststore.sh
+	[--keystorepassword <non empty password for the keystore, default: 'password'>]
+	[--destdir <existing dir, default: '.'>]"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+	
+	--keystorepassword )     shift
+                                 KEYSTORE_PASSWORD=$1
+                                 ;;
+
+	--destdir )              shift
+                                 DEST_DIR=${1%/}/
+                                 ;;
+
+        * )                      usage
+                                 exit 1
+    esac
+    shift
+done
+
+if [ -z "$KEYSTORE_PASSWORD" ]; then
+    echo "Empty password for the keystore specified ..."
+    echo " "
+    usage
+    exit -1
+fi
+
+
+if [ -z "$DEST_DIR" ]; then
+    echo "No destination directory specified. Using current directory"
+fi
+
+
+cd "$DEST_DIR"
+
+
+# create JKS truststore
+keytool -keystore catruststore.jks -importcert -file $CERT_PATH/ca.cert.pem -storepass $KEYSTORE_PASSWORD -trustcacerts -noprompt
+
+# list the truststore contents
+keytool -list -keystore catruststore.jks -storepass $KEYSTORE_PASSWORD
+
+# create PKCS12 truststore
+keytool -importkeystore -srckeystore catruststore.jks -srcstorepass $KEYSTORE_PASSWORD -destkeystore catruststore.p12 -deststorepass $KEYSTORE_PASSWORD -srcstoretype JKS -deststoretype PKCS12  -noprompt
+
+# merge and import client certificate and private key into pkcs12 keystore
+openssl pkcs12 -export -in $CERT_PATH/client.cert.pem -inkey $PRIVATE_KEY_PATH/client.key.pem -out clientkeystore.p12 -password pass:$KEYSTORE_PASSWORD
+
+# convert pkcs12 keystore into java keystore
+keytool -delete -importkeystore -deststorepass $KEYSTORE_PASSWORD -destkeypass $KEYSTORE_PASSWORD -destkeystore clientkeystore.jks -srckeystore clientkeystore.p12 -srcstoretype PKCS12 -srcstorepass $KEYSTORE_PASSWORD -alias 1 -storepass $KEYSTORE_PASSWORD -noprompt
+
+# list the keystore contents
+keytool -list -keystore clientkeystore.jks -storepass $KEYSTORE_PASSWORD

--- a/java/messaging/mqtt/joynr-mqtt-client/scripts/gen-java-keystore-truststore.sh
+++ b/java/messaging/mqtt/joynr-mqtt-client/scripts/gen-java-keystore-truststore.sh
@@ -64,3 +64,6 @@ keytool -delete -importkeystore -deststorepass $KEYSTORE_PASSWORD -destkeypass $
 
 # list the keystore contents
 keytool -list -keystore clientkeystore.jks -storepass $KEYSTORE_PASSWORD
+
+# always return success (don't break the maven build in case of something went wrong)
+exit 0


### PR DESCRIPTION
This PR fixes #30 and #36

The maven project `java/messaging/mqtt/joynr-mqtt-client` requires additional files during the unit tests. These files are only created through `docker/joynr-android/scripts/build/java-android-clean-build`. If this script wasn't executed in the past, the files are not available and some tests will fail. This PR moves the creation of the required files from `docker/joynr-android/scripts/build/java-android-clean-build` into a separate shell script. 

The maven project (`java/messaging/mqtt/joynr-mqtt-client`) itself executes this new shell script during the maven phase `generate-test-resources` to ensure the files are available during the tests. With this change it doesn't matter how the unit tests are started.