### PR TITLE
Protect against potential ZipSlip attack

### DIFF
--- a/java/javaapi/src/main/java/io/joynr/util/JoynrUtil.java
+++ b/java/javaapi/src/main/java/io/joynr/util/JoynrUtil.java
@@ -223,6 +223,8 @@ public class JoynrUtil {
                         InputStream is = jf.getInputStream(ze);
                         String name = ze.getName().substring(ze.getName().lastIndexOf("/") + 1);
                         File tmpFile = new File(tmpDir + "/" + name); //File.createTempFile(file.getName(), "tmp");
+                        if (!tmpFile.toPath().normalize().startsWith(tmpDir.toPath().normalize()))
+                            throw new Exception("Bad zip entry");
                         tmpFile.deleteOnExit();
                         OutputStream outputStreamRuntime = new FileOutputStream(tmpFile);
                         copyStream(is, outputStreamRuntime);


### PR DESCRIPTION
* prevent potential [ZipSlip attack](https://snyk.io/research/zip-slip-vulnerability)
* while the use of "/" is prevented in the current code, it may be possible to construct a ZipEntry with a backslash ("\\“) that leads to path escaping if the code is run under Windows
* fix checks that destination file is inside tmp directory and no path escaping is attempted
* possible vulnerability identified with [LGTM](https://lgtm.com/projects/g/bmwcarit/joynr/snapshot/77437ccbd9cb93403022a1badda20f403f6ad315/files/java/javaapi/src/main/java/io/joynr/util/JoynrUtil.java?sort=name&dir=ASC&mode=heatmap#xdf14873cd673f752:1)